### PR TITLE
Use xml over json

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
                   name: Run tests
                   command: |
                       pipenv run coverage run -m pytest ./tests
-                      pipenv run coverage json
+                      pipenv run coverage xml
                       bash <(curl -s https://codecov.io/bash)
             - store_artifacts:
                   path: coverage


### PR DESCRIPTION
fixes https://community.codecov.io/t/coverage-reports-not-appearing-in-codecov-dashboard/2721

Codecov does not process the `json` format produced by `coverage` properly, but we do process the `xml` format.