### PR TITLE
Rename project from PyFORC to pyforc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-[![codecov](https://codecov.io/gh/peytondmurray/PyFORC/branch/develop/graph/badge.svg?token=0fxoMUIK6x)](https://codecov.io/gh/peytondmurray/PyFORC)
 [![MIT license](https://img.shields.io/badge/License-MIT-blue.svg)](https://lbesson.mit-license.org/)
 
-# PyFORC
+# pyforc
 
 FORC analysis in Python.
 ![A FORC distribution plot.](./assets/forc.jpg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 name = "pyforc"
 dynamic = ["version"]
 authors = [
-  { name="Peyton  Murray" },
+  { name="Peyton Murray" },
 ]
 description = "FORC analysis in Python"
 readme = "README.md"


### PR DESCRIPTION
This PR renames the project from the case-sensitive and user-unfriendly `PyFORC` to `pyforc`, which is easier to type.