### PR TITLE
Import the public API into pyforc.core; privatize some functions

### DIFF
--- a/src/pyforc/core/__init__.py
+++ b/src/pyforc/core/__init__.py
@@ -1,1 +1,12 @@
-from . import config, coordinates, forc, forcdata, ingester, ops, plot
+from .config import Config
+from .coordinates import Coordinates, CoordinatesHcHb, CoordinatesHHr
+from .forc import Forc
+from .forcdata import ForcData
+from .ingester import PMCIngester
+from .ops import (
+    compute_forc_distribution,
+    correct_drift,
+    correct_slope,
+    interpolate,
+    normalize,
+)


### PR DESCRIPTION
This PR solidifies the public API somewhat:

- Make all functions in `pyforc.core.ops` that aren't actually operations private
- Explicitly import all functions/classes that are part of the public API into the `pyforc.core` module