### PR TITLE
Add hypothesis tests for coordinate transformations

### DIFF
--- a/pyforc/core/coordinates.py
+++ b/pyforc/core/coordinates.py
@@ -31,7 +31,8 @@ class Coordinates(transforms.Affine2D):
             if subc.name == name:
                 return subc()
 
-        raise ValueError(f"Invalid coordinate type {name}")
+        names = [subc.name for name in Coordinates.__subclasses__()]
+        raise ValueError(f"Invalid coordinate type {name}. Valid names: {names}")
 
 
 class CoordinatesHcHb(Coordinates):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ profile = "black"
 
 [project.optional-dependencies]
 dev = ["pre-commit>=3.6.0"]
-test = ["pytest", "pytest-cov"]
+test = ["pytest", "pytest-cov", "hypothesis"]
 doc = ["sphinx", "myst-parser"]
 
 [tool.ruff]

--- a/tests/core/test_coordinates.py
+++ b/tests/core/test_coordinates.py
@@ -1,0 +1,65 @@
+import numpy as np
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+
+from pyforc.core import Coordinates, CoordinatesHcHb, CoordinatesHHr
+
+
+@pytest.mark.parametrize(
+    ("coord_str", "expected"),
+    [
+        ("hchb", CoordinatesHcHb),
+        ("hhr", CoordinatesHHr),
+    ],
+)
+def test_from_str(coord_str, expected):
+    """Test that the right Coordinates subclass is returned for each string."""
+    assert isinstance(Coordinates.from_str(coord_str), expected)
+
+
+def test_from_str_invalid():
+    """Test that an invalid name raises an error for Coordinates.from_str()."""
+    name = "foo"
+    with pytest.raises(ValueError, match=f"Invalid coordinate type {name}"):
+        Coordinates.from_str(name)
+
+
+@given(
+    st.floats(min_value=-2 * 53 - 1, max_value=2 * 53 - 1),
+    st.floats(min_value=-2 * 53 - 1, max_value=2 * 53 - 1),
+)
+def test_hchb_matrix(h, hr):
+    """Test that the hchb coordinate matrix transforms coordinates as expected."""
+    hhr_vec = np.array([h, hr, 0])
+
+    coords = CoordinatesHcHb()
+    assert coords.has_inverse
+
+    arr = np.array(coords.get_matrix())
+
+    [hc, hb, _] = arr @ hhr_vec
+
+    assert np.isclose(h, hb + hc)
+    assert np.isclose(hr, hb - hc)
+    assert np.isclose(hc, (h - hr) / 2)
+    assert np.isclose(hb, (h + hr) / 2)
+
+
+@given(
+    st.floats(min_value=-2 * 53 - 1, max_value=2 * 53 - 1),
+    st.floats(min_value=-2 * 53 - 1, max_value=2 * 53 - 1),
+)
+def test_hhr_matrix(h, hr):
+    """Test that the hhr coordinate matrix transforms coordinates as expected."""
+    hhr_vec = np.array([h, hr, 0])
+
+    coords = CoordinatesHHr()
+    assert coords.has_inverse
+
+    arr = np.array(coords.get_matrix())
+
+    [h_calc, hr_calc, _] = arr @ hhr_vec
+
+    assert h_calc == h
+    assert hr_calc == hr


### PR DESCRIPTION
This PR adds a test dependency on `hypothesis`, and writes a few tests for the `Coordinates` classes.